### PR TITLE
129 Weglaten van teacherId bij createAnnouncement

### DIFF
--- a/server/domain/announcement.domain.ts
+++ b/server/domain/announcement.domain.ts
@@ -1,11 +1,12 @@
 import { AnnouncementPersistence } from "../persistence/announcement.persistence";
 import {
   AnnouncementByFilterParams,
-  AnnouncementCreateParams,
-  AnnouncementCreateSchema,
+  AnnouncementCreateDomainParams,
+  AnnouncementCreateDomainSchema,
   AnnouncementFilterSchema,
   AnnouncementUpdateParams,
   AnnouncementUpdateSchema,
+  TeacherIdSchema,
 } from "../util/types/announcement.types";
 import { PaginationFilterSchema } from "../util/types/pagination.types";
 
@@ -34,14 +35,23 @@ export class AnnouncementDomain {
     );
   }
 
-  public async createAnnouncement(query: AnnouncementCreateParams) {
+  public async createAnnouncement(query: AnnouncementCreateDomainParams) {
     // TODO check if this is allowed by using cookies
 
-    const parseResult = AnnouncementCreateSchema.safeParse(query);
+    const parseResult = AnnouncementCreateDomainSchema.safeParse(query);
     if (!parseResult.success) {
       throw parseResult.error;
     }
-    return this.announcementPersistence.createAnnouncement(parseResult.data);
+
+    const teacherIdParseResult = TeacherIdSchema.safeParse(query);
+    if (!teacherIdParseResult.success) {
+      throw teacherIdParseResult.error;
+    }
+
+    return this.announcementPersistence.createAnnouncement({
+      ...parseResult.data,
+      teacherId: teacherIdParseResult.data,
+    });
   }
 
   public async updateAnnouncement(query: AnnouncementUpdateParams) {

--- a/server/persistence/announcement.persistence.ts
+++ b/server/persistence/announcement.persistence.ts
@@ -1,7 +1,7 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import {
   AnnouncementByFilterParams,
-  AnnouncementCreateParams,
+  AnnouncementCreatePersistenceParams,
   AnnouncementUpdateParams,
 } from "../util/types/announcement.types";
 import { PaginationParams } from "../util/types/pagination.types";
@@ -55,7 +55,7 @@ export class AnnouncementPersistence {
   }
 
   public async createAnnouncement(
-    announcementCreateParams: AnnouncementCreateParams,
+    announcementCreateParams: AnnouncementCreatePersistenceParams,
   ) {
     const { classId, teacherId, ...data } = announcementCreateParams;
     const announcement = await PrismaSingleton.instance.announcement.create({

--- a/server/util/types/announcement.types.ts
+++ b/server/util/types/announcement.types.ts
@@ -13,12 +13,20 @@ export const AnnouncementFilterSchema = z
     path: [],
   });
 
-export const AnnouncementCreateSchema = z.object({
+export const AnnouncementCreatePersistenceSchema = z.object({
   title: z.string().min(1, "Title must be a non-empty string").trim(),
   content: z.string().min(1, "Content must be a non-empty string").trim(),
   classId: z.string(),
   teacherId: z.string(),
 });
+
+export const AnnouncementCreateDomainSchema = z.object({
+  title: z.string().min(1, "Title must be a non-empty string").trim(),
+  content: z.string().min(1, "Content must be a non-empty string").trim(),
+  classId: z.string(),
+});
+
+export const TeacherIdSchema = z.string();
 
 export const AnnouncementUpdateSchema = z.object({
   id: z.string().uuid("Id must be a valid UUID"),
@@ -37,5 +45,11 @@ export const AnnouncementUpdateSchema = z.object({
 export type AnnouncementByFilterParams = z.infer<
   typeof AnnouncementFilterSchema
 >;
-export type AnnouncementCreateParams = z.infer<typeof AnnouncementCreateSchema>;
+export type AnnouncementCreatePersistenceParams = z.infer<
+  typeof AnnouncementCreatePersistenceSchema
+>;
+export type AnnouncementCreateDomainParams = z.infer<
+  typeof AnnouncementCreateDomainSchema
+>;
+export type TeacherId = z.infer<typeof TeacherIdSchema>;
 export type AnnouncementUpdateParams = z.infer<typeof AnnouncementUpdateSchema>;


### PR DESCRIPTION
De implementatie is simpel.

Ik heb AnnouncementCreateSchema in drie opgesplitst:
- AnnouncementCreatePersistenceSchema: hetzelfde als AnnouncementCreateSchema maar dient enkel als type voor het argument bij createAnnouncement in persistence.
- AnnouncementCreateDomainSchema: hetzelfde als AnnouncementCreateSchema buiten dat teacherId er niet meer bij zit. Zo kan er getest worden zonder teacherId. Dit dient ook als type voor het argument bij createAnnouncement in domain.
- TeacherIdSchema: deze dient enkel om te checken of het een defined string is (niet optional). Ik heb het op deze manier gedaan om consistent met de zod-validation-stijl te blijven. Dit kan natuurlijk simpeler, laat maar weten of het anders moet.

Ik moet het nog lokaal testen.