### PR TITLE
283 name en description field toevoegen aan assignment

### DIFF
--- a/client/src/util/interfaces/assignment.interfaces.ts
+++ b/client/src/util/interfaces/assignment.interfaces.ts
@@ -5,17 +5,21 @@ import { TeacherShort } from './teacher.interfaces';
 
 export interface AssignmentShort {
   id: string;
+  name: string;
   learningPathId: string;
 }
 
 export interface AssignmentShort2 {
   id: string;
+  name: string;
   groups: GroupShort[];
   learningPath: LearningPathDetail;
 }
 
 export interface AssignmentDetail {
   id: string;
+  name: string;
+  description: string;
   teacher: TeacherShort;
   class: ClassShort;
   groups: GroupShort[];
@@ -24,6 +28,8 @@ export interface AssignmentDetail {
 
 export interface PopulatedAssignment {
   id: string;
+  name: string;
+  description: string;
   teacherId: string;
   class: ClassShort;
   groups: GroupShort[];
@@ -31,6 +37,8 @@ export interface PopulatedAssignment {
 }
 
 export interface AssignmentCreate {
+  name: string;
+  description: string;
   groups: string[][];
   learningPathId: string;
   classId: string;

--- a/client/src/util/locale/en.ts
+++ b/client/src/util/locale/en.ts
@@ -81,5 +81,7 @@ export const en = {
     submission: 'Submission',
     back: 'Back',
     score: 'Score',
+    assignmentNameRequired: 'Assignment name is required',
+    learningPathRequired: 'Learning path is required',
   },
 };

--- a/client/src/util/locale/fr.ts
+++ b/client/src/util/locale/fr.ts
@@ -83,5 +83,7 @@ export const fr = {
     submission: 'Soumission',
     back: 'Retourner',
     score: 'Score',
+    assignmentNameRequired: 'Le nom du devoir est requis',
+    learningPathRequired: "Le parcours d'apprentissage est requis",
   },
 };

--- a/client/src/util/locale/nl.ts
+++ b/client/src/util/locale/nl.ts
@@ -80,5 +80,7 @@ export const nl = {
     submission: 'Indiening',
     back: 'Terug',
     score: 'Score',
+    assignmentNameRequired: 'Opdrachtnaam is verplicht',
+    learningPathRequired: 'Leerpad is verplicht',
   },
 };

--- a/client/src/views/AssignmentCreatePage.tsx
+++ b/client/src/views/AssignmentCreatePage.tsx
@@ -62,6 +62,8 @@ function AssignmentCreatePage() {
     useState<LearningPathShort[]>(learningPaths);
   const [selectedLearningPath, setSelectedLearningPath] = useState<LearningPathShort | null>(null);
   const [groups, setGroups] = useState<StudentShort[][]>(studentsData.map((student) => [student]));
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
 
   useEffect(() => {
     const updatedPaths = learningPaths.filter(
@@ -95,6 +97,8 @@ function AssignmentCreatePage() {
   const handleSubmit = () => {
     //TODO: add (name, description) and deadline
     const data: AssignmentCreate = {
+      name: name,
+      description: description,
       classId: classId!,
       teacherId: teacherId!,
       groups: groups.map((group) => group.map((student) => student.id)),
@@ -155,6 +159,8 @@ function AssignmentCreatePage() {
               variant="outlined"
               margin="normal"
               fullWidth
+              value={name}
+              onChange={(e) => setName(e.target.value)}
             />
             <TextField
               id="description-assignment"
@@ -164,6 +170,8 @@ function AssignmentCreatePage() {
               margin="dense"
               rows={5}
               fullWidth
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
             />
             <DateTextField />
           </Grid>

--- a/client/src/views/AssignmentCreatePage.tsx
+++ b/client/src/views/AssignmentCreatePage.tsx
@@ -161,6 +161,7 @@ function AssignmentCreatePage() {
               fullWidth
               value={name}
               onChange={(e) => setName(e.target.value)}
+              helperText={`${name.length}/255`}
             />
             <TextField
               id="description-assignment"
@@ -172,6 +173,8 @@ function AssignmentCreatePage() {
               fullWidth
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              slotProps={{ htmlInput: { maxLength: 500 } }}
+              helperText={`${description.length}/500`}
             />
             <DateTextField />
           </Grid>

--- a/client/src/views/AssignmentCreatePage.tsx
+++ b/client/src/views/AssignmentCreatePage.tsx
@@ -95,7 +95,16 @@ function AssignmentCreatePage() {
   };
 
   const handleSubmit = () => {
-    //TODO: add (name, description) and deadline
+    //TODO: deadline
+    if (!name.trim()) {
+      setError(t('assignmentNameRequired'));
+      return;
+    }
+    if (!selectedLearningPath) {
+      setError(t('learningPathRequired'));
+      return;
+    }
+
     const data: AssignmentCreate = {
       name: name,
       description: description,

--- a/client/src/views/ClassAssignmentPage.tsx
+++ b/client/src/views/ClassAssignmentPage.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   LinearProgress,
   Paper,
+  Stack,
   Table,
   TableBody,
   TableCell,
@@ -61,14 +62,39 @@ function ClassAssignmentPage() {
       <Box sx={{ mx: 'auto', width: '100%', maxWidth: { xs: '90%', sm: 1000 }, p: 2 }}>
         <BackButton link={`/class/${classData!.id}/assignments`} />
 
-        <Typography variant="h3" gutterBottom>
-          {/*assignment!.name*/}
-          {assignment!.learningPath.title}
-        </Typography>
-        <Typography variant="h5" gutterBottom>
-          {`${t('givenBy')}: ${assignment!.teacher.user.name} ${assignment!.teacher.user.surname}`}
-        </Typography>
+        <Stack spacing={3} sx={{ mb: 4 }}>
+          <Typography variant="h3">{assignment!.name}</Typography>
 
+          <Box
+            sx={{
+              backgroundColor: '#f9f9f9',
+              borderRadius: 2,
+              p: 2,
+              boxShadow: 1,
+              position: 'relative',
+            }}
+          >
+            {/* Given By - top right */}
+            <Typography
+              variant="subtitle2"
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 12,
+                fontStyle: 'italic',
+                color: 'text.secondary',
+              }}
+            >
+              {t('givenBy')}: {assignment!.teacher.user.name} {assignment!.teacher.user.surname}
+            </Typography>
+
+            {/* Description content */}
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
+              {t('description')}
+            </Typography>
+            <Typography variant="body1">{assignment!.description}</Typography>
+          </Box>
+        </Stack>
         {/*<DateTypography text={`${t('deadline')}: `} date={assignment.deadline} variant='h5' />*/}
 
         <GroupListDialog

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -174,6 +174,8 @@ model Group {
 
 model Assignment {
   id             String       @id @default(uuid())
+  name           String
+  description    String?
   learningPathId String
   teacherId      String
   classId        String
@@ -232,12 +234,12 @@ model Message {
 }
 
 model Announcement {
-  id        String  @id @default(uuid())
+  id        String   @id @default(uuid())
   title     String
   content   String
   classId   String
   createdAt DateTime @default(now()) @db.Timestamp
-  class     Class   @relation(fields: [classId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  class     Class    @relation(fields: [classId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   teacherId String
-  teacher   Teacher @relation(fields: [teacherId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  teacher   Teacher  @relation(fields: [teacherId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -175,7 +175,7 @@ model Group {
 model Assignment {
   id             String       @id @default(uuid())
   name           String
-  description    String?
+  description    String
   learningPathId String
   teacherId      String
   classId        String

--- a/server/persistence/assignment.persistence.ts
+++ b/server/persistence/assignment.persistence.ts
@@ -90,6 +90,8 @@ export class AssignmentPersistence {
     //create assignment
     const assignment = await PrismaSingleton.instance.assignment.create({
       data: {
+        name: params.name,
+        description: params.description,
         class: {
           connect: {
             id: params.classId,

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -893,6 +893,16 @@
             "description": "The unique identifier for the assignment.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
           },
+          "name": {
+            "type": "string",
+            "description": "The name of the assignment.",
+            "example": "Assignment 1"
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the assignment.",
+            "example": "This is the first assignment."
+          },
           "learningPath": {
             "$ref": "#/components/schemas/LearningPathShort"
           },
@@ -922,6 +932,11 @@
             "format": "uuid",
             "description": "The unique identifier for the assignment.",
             "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the assignment.",
+            "example": "Assignment 1"
           },
           "learningPathId": {
             "type": "string",
@@ -1567,6 +1582,16 @@
       "AssignmentCreate": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the assignment.",
+            "example": "Math Assignment 1"
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the assignment.",
+            "example": "Solve the problems in chapter 1."
+          },
           "groups": {
             "type": "array",
             "description": "The groups that are assigned to the assignment",

--- a/server/util/selectInput/select.ts
+++ b/server/util/selectInput/select.ts
@@ -208,6 +208,7 @@ export const classSelectDetail = {
 
 export const assignmentSelectShort2 = {
   id: true,
+  name: true,
   groups: {
     select: groupSelectShort,
   },
@@ -230,6 +231,8 @@ export const assignmentSelectShort2 = {
 
 export const assignmentSelectDetail = {
   id: true,
+  name: true,
+  description: true,
   teacher: {
     select: teacherSelectShort,
   },

--- a/server/util/selectInput/select.ts
+++ b/server/util/selectInput/select.ts
@@ -189,6 +189,7 @@ export const learningPathSelectDetail = {
 
 export const assignmentSelectShort = {
   id: true,
+  name: true,
   learningPathId: true,
 };
 

--- a/server/util/types/assignment.types.ts
+++ b/server/util/types/assignment.types.ts
@@ -21,8 +21,8 @@ export const AssignmentFilterSchema = z
 export const IdSchema = z.string().uuid();
 
 export const AssignmentCreateSchema = z.object({
-  name: z.string().min(1).max(255),
-  description: z.string().min(1).max(255).optional(),
+  name: z.string().min(1).max(100),
+  description: z.string().min(0).max(500),
   groups: z.string().uuid().array().nonempty().array().nonempty(),
   classId: z.string().uuid(),
   teacherId: z.string().uuid().optional(),

--- a/server/util/types/assignment.types.ts
+++ b/server/util/types/assignment.types.ts
@@ -21,6 +21,8 @@ export const AssignmentFilterSchema = z
 export const IdSchema = z.string().uuid();
 
 export const AssignmentCreateSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().min(1).max(255).optional(),
   groups: z.string().uuid().array().nonempty().array().nonempty(),
   classId: z.string().uuid(),
   teacherId: z.string().uuid().optional(),


### PR DESCRIPTION
Ik heb ook kleine aanpassingen gemaakt aan de view. Zo heb ik de "creator" rechtsboven in de description box gezet ipv dat zowel name, description en creator onder elkaar stonden. 
![image](https://github.com/user-attachments/assets/a4359af9-cbf1-41a6-a1eb-bc3d8c801e53)


Ook heb ik een charactercounter gezet onder de name en description fields die aangeeft hoeveel van de max chars er al gebruikt zijn. Deze max lengths zijn voorlopig hardgecodeerd in de views zelf, maar zullen op termijn gekoppeld moeten worden aan de max_length die in het zod_schema gebruikt wordt
![image](https://github.com/user-attachments/assets/4df96402-ffe5-46eb-a914-00fb1f6bd13d)
